### PR TITLE
Fix a few broken markdown links

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,9 +466,9 @@ Why code in all of these?
 I may not have time to do all of these for every subject, but I'll try.
 
 You can see my code here:
- - [C] (https://github.com/jwasham/practice-c)
- - [C++] (https://github.com/jwasham/practice-cpp)
- - [Python] (https://github.com/jwasham/practice-python)
+ - [C](https://github.com/jwasham/practice-c)
+ - [C++](https://github.com/jwasham/practice-cpp)
+ - [Python](https://github.com/jwasham/practice-python)
 
 You don't need to memorize the guts of every algorithm.
 


### PR DESCRIPTION
Sometime in the last month or so several markdown links broke across all of github, 
likely due to a change to the way that they parse markdown. This PR fixes the affected
links that I found here.