### PR TITLE
Changed duplicate resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -1770,7 +1770,7 @@ software engineer, and to be aware of certain technologies and algorithms, so yo
     - [ ] [For animations and a little more detail](https://en.wikipedia.org/wiki/Skip_list)
 
 - ### Network Flows
-    - [ ] [Ford-Fulkerson in 5 minutes (video)](https://www.youtube.com/watch?v=v1VgJmkEJW0)
+    - [ ] [Ford-Fulkerson in 5 minutes — Step by step example (video)](https://www.youtube.com/watch?v=Tl90tNtKvxs)
     - [ ] [Ford-Fulkerson Algorithm (video)](https://www.youtube.com/watch?v=v1VgJmkEJW0)
     - [ ] [Network Flows (video)](https://www.youtube.com/watch?v=2vhN4Ice5jI)
 


### PR DESCRIPTION
"Ford-Fulkerson in 5 minutes (video)" had the same URL as "Ford-Fulkerson Algorithm (video)".

So I found a relevant video that explains "Ford-Fulkerson in 5 minutes" and changed the URL to that video.

See if you're fine with the video I chose.