### PR TITLE
add 한국어 for Korean to easy to spot

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Translations in progress:
 - [Russian](https://github.com/jwasham/coding-interview-university/issues/87)
 - [Ukrainian](https://github.com/jwasham/coding-interview-university/issues/106)
 - [Brazilian Portuguese](https://github.com/jwasham/coding-interview-university/issues/113)
-- [Korean](https://github.com/jwasham/coding-interview-university/issues/118)
+- [Korean(한국어)](https://github.com/jwasham/coding-interview-university/issues/118)
 - [Telugu](https://github.com/jwasham/coding-interview-university/issues/117)
 - [Polish](https://github.com/jwasham/coding-interview-university/issues/122)
 - [German](https://github.com/jwasham/coding-interview-university/issues/135)


### PR DESCRIPTION
I just added "한국어" for Korean to find its link easily. I wasn't noticed there is a Korean version. So I did. We might add it all with other languages too.