### PR TITLE
Fixes #368 Fix broken links for Sedgewick and Wayne algorithms lectures.

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,9 +331,9 @@ If you have a better recommendation for C++, please let me know. Looking for a c
 ### Java
 
 - [ ] [Algorithms (Sedgewick and Wayne)](https://www.amazon.com/Algorithms-4th-Robert-Sedgewick/dp/032157351X/)
-    - videos with book content (and Sedgewick!):
-        - [Algorithms I](https://www.youtube.com/user/algorithmscourses/playlists?view=50&sort=dd&shelf_id=2)
-        - [Algorithms II](https://www.youtube.com/user/algorithmscourses/playlists?shelf_id=3&view=50&sort=dd)
+    - videos with book content (and Sedgewick!) on coursera:
+        - [Algorithms I](https://www.coursera.org/learn/algorithms-part1)
+        - [Algorithms II](https://www.coursera.org/learn/algorithms-part2)
 
 OR:
 


### PR DESCRIPTION
The videos are now on Coursera.