### PR TITLE
Fix link to the main article (English) at Spanish translation

### DIFF
--- a/translations/README-es.md
+++ b/translations/README-es.md
@@ -1,6 +1,6 @@
 ﻿# Coding Interview University
 
-- Versión original: [Inglés](README.md)
+- Versión original: [Inglés](../README.md)
 
 > Originalmente creé esto como una lista corta de tópicos a estudiar para volverse un Ingeniero de Software, pero creció hasta ser la gran lista puede apreciar actualmente. Después de pasar por este plan de estudios ¡[fui contratado como Ingeniero de Desarrollo de Software en Amazon!(Art. Inglés)](https://startupnextdoor.com/ive-been-acquired-by-amazon/?src=ciu)
 


### PR DESCRIPTION
The link to the main article was broken in the Spanish translation. It redirected to a non-existent file. That it's because the link is for `translations/README.md` which doesn't exist. I've linked to the `README.md` of the previous folder (root folder).