### PR TITLE
Remove OOP link from Extra Topics & Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,6 @@ software development/engineering roles.
 - [Even More Knowledge](#even-more-knowledge)
     - [Recursion](#recursion)
     - [Dynamic Programming](#dynamic-programming)
-    - [Object-Oriented Programming](#object-oriented-programming)
     - [Design Patterns](#design-patterns)
     - [Combinatorics (n choose k) & Probability](#combinatorics-n-choose-k--probability)
     - [NP, NP-Complete and Approximation Algorithms](#np-np-complete-and-approximation-algorithms)


### PR DESCRIPTION
The Object-Oriented Programming section was removed but the link to that section wasn't. This commit removes that link. 

Thanks.