### PR TITLE
Remove Scheduling link from Extra Topics & Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,6 @@ software development/engineering roles.
     - [Caches](#caches)
     - [Processes and Threads](#processes-and-threads)
     - [Testing](#testing)
-    - [Scheduling](#scheduling)
     - [String searching & manipulations](#string-searching--manipulations)
     - [Tries](#tries)
     - [Floating Point Numbers](#floating-point-numbers)


### PR DESCRIPTION
The Scheduling section was removed but the link to that section wasn't. This commit removes that link.

Thanks.