### PR TITLE
Fix Networking: Khan Academy broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1171,7 +1171,7 @@ Graphs can be used to represent many problems in computer science, so this secti
 - ### Networking
     - **if you have networking experience or want to be a reliability engineer or operations engineer, expect questions**
     - Otherwise, this is just good to know
-    - [ ] [Khan Academy](https://www.khanacademy.org/computing/computer-science/computers-and-internet-code-org)
+    - [ ] [Khan Academy](https://www.khanacademy.org/computing/code-org/computers-and-the-internet)
     - [ ] [UDP and TCP: Comparison of Transport Protocols (video)](https://www.youtube.com/watch?v=Vdc8TCESIg8)
     - [ ] [TCP/IP and the OSI Model Explained! (video)](https://www.youtube.com/watch?v=e5DEVa9eSN0)
     - [ ] [Packet Transmission across the Internet. Networking & TCP/IP tutorial. (video)](https://www.youtube.com/watch?v=nomyRJehhnM)


### PR DESCRIPTION
The current Networking: Khan Academy [link](https://www.khanacademy.org/computing/computer-science/computers-and-internet-code-org) is broken. This pull request updates it with a working [one](https://www.khanacademy.org/computing/code-org/computers-and-the-internet).