### PR TITLE
fix: Add missing cmd on clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Fork the GitHub repo https://github.com/jwasham/coding-interview-university by c
 Clone to your local repo:
 
     git clone git@github.com:<your_github_username>/coding-interview-university.git
+    cd coding-interview-university
     git checkout -b progress
     git remote add jwasham https://github.com/jwasham/coding-interview-university
     git fetch --all


### PR DESCRIPTION
After cloning the repo, the command steps to add a progress branch was not changing to the new cloned directory before creating and checking out to the progress branch.