### PR TITLE
Outdated QuickSort link in QuickSort of Sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -857,7 +857,7 @@ if you can identify the runtime complexity of different algorithms. It's a super
     - [ ] [5. Stability](https://www.coursera.org/learn/algorithms-part1/lecture/pvvLZ/stability)
 
 - [ ] [Sedgewick - Quicksort (4 videos)](https://www.coursera.org/learn/algorithms-part1/home/week/3)
-    - [ ] [1. Quicksort](https://www.coursera.org/learn/algorithms-part1/lecture/vjvnC/quicksort)
+    - [ ] [1. Quicksort](https://www.coursera.org/lecture/algorithms-part1/quicksort-vjvnC)
     - [ ] [2. Selection](https://www.coursera.org/lecture/algorithms-part1/selection-UQxFT)
     - [ ] [3. Duplicate Keys](https://www.coursera.org/lecture/algorithms-part1/duplicate-keys-XvjPd)
     - [ ] [4. System Sorts](https://www.coursera.org/lecture/algorithms-part1/system-sorts-QBNZ7)


### PR DESCRIPTION
The link in QuickSort in the QuickSort section of Sorting is outdated , so I found the new link in the Coursera and updated it 
>QuickSort
QuickSort(video)
