### PR TITLE
Add free linux commands tutorials and DevOps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1557,7 +1557,7 @@ You're never really done.
 	- [The Absolute Beginner's Guide to Emacs (video by David Wilson)](https://www.youtube.com/watch?v=48JlgiBpw_I&t=0s)
 	- [The Absolute Beginner's Guide to Emacs (notes by David Wilson)](https://systemcrafters.net/emacs-essentials/absolute-beginners-guide-to-emacs/)
 
-- ### Unix command line tools
+- ### Unix/Linux command line tools
     - I filled in the list below from good tools.
     - bash
     - cat
@@ -1570,6 +1570,10 @@ You're never really done.
     - uniq
     - [strace](https://en.wikipedia.org/wiki/Strace)
     - [tcpdump](https://danielmiessler.com/study/tcpdump/)
+    - [Essential Linux Commands Tutorial](https://labex.io/tutorials/practice-linux-commands-hands-on-labs-398420)
+
+- ### DevOps
+    - [DevOps Roadmap](https://roadmap.sh/devops)
 
 - ### Information theory (videos)
     - [Khan Academy](https://www.khanacademy.org/computing/computer-science/informationtheory)


### PR DESCRIPTION
I work at LabEx, a unique learning platform that has offered Linux and DevOps hands-on labs to university students for 7 years. Based on our experience, these skills are valuable for computer science job interviews, so we've added a Linux commands tutorial and a DevOps roadmap.

This repo is a great resource for students. Please let me know if any changes are needed.